### PR TITLE
Add detail to the Building section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ Copy the contents of `vultr/` to Packer's source tree:
 $ cp -r ${GOPATH:-~/go}/src/github.com/dradtke/packer-builder-vultr/vultr ${GOPATH:-~/go}/src/github.com/hashicorp/packer/builder/
 ```
 
-Then open up Packer's file `command/plugin.go` and add Vultr as a new builder.
+Then open up Packer's file `command/plugin.go` and add Vultr as a new builder:
+ - in `import` secion add: `vultrbuilder "github.com/hashicorp/packer/builder/vultr"`
+ - in `Builders` map add: `"vultr":   new(vultrbuilder.Builder),`
+ 
 Then you can `go install` Packer, and it will have support for the "vultr"
 plugin.
 


### PR DESCRIPTION
It wasn't clear from the instructions what I should do to "add Vultr as a new builder". I found `go generate` in the Makefile, which gave me the lines to add. This PR adds those lines to the README.