### PR TITLE
Support attaching existing SSH key

### DIFF
--- a/vultr/config.go
+++ b/vultr/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	OSName          string `mapstructure:"os_name"`
 	ScriptID        int    `mapstructure:"script_id"`
 	SnapshotID      string `mapstructure:"snapshot_id"`
+	SSHKey          string `mapstructure:"ssh_key_id"`
 	SSHUsername     string `mapstructure:"ssh_username"`
 	SSHPassword     string `mapstructure:"ssh_password"`
 	ShutdownCommand string `mapstructure:"shutdown_command"`

--- a/vultr/step_create.go
+++ b/vultr/step_create.go
@@ -20,6 +20,7 @@ func (s *stepCreate) Run(_ context.Context, state multistep.StateBag) multistep.
 	opts := &vultr.ServerOptions{
 		Script:               c.ScriptID,
 		DontNotifyOnActivate: true,
+		SSHKey:               c.SSHKey,
 	}
 	if c.OSID == SnapshotOSID {
 		opts.Snapshot = c.SnapshotID


### PR DESCRIPTION
I really can't figure out where Vultr attaches it (!) - but I have tested and verified that it works after creating a new server from the snapshot.