### PR TITLE
Installing no longer requires Packer source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,21 @@ Vultr builder plugin for Packer
 
 A Packer builder for creating Vultr snapshots.
 
-## Building
+## Installing
 
-Due to vendoring issues, at the moment this package must be built from within
-Packer's source code. So, fetch this repo and Packer:
+- Ensure you have the Packer plugin directory:
 
-```sh
-$ go get -d github.com/hashicorp/packer
-$ go get -d github.com/dradtke/packer-builder-vultr
-```
+`mkdir -p ~/.packer.d/plugins`
 
-Copy the contents of `vultr/` to Packer's source tree:
+- Install the plugin binary:
 
-```sh
-$ cp -r ${GOPATH:-~/go}/src/github.com/dradtke/packer-builder-vultr/vultr ${GOPATH:-~/go}/src/github.com/hashicorp/packer/builder/
-```
+`GO111MODULE=on go get github.com/dradtke/packer-builder-vultr`
 
-Then open up Packer's file `command/plugin.go` and add Vultr as a new builder:
- - in `import` secion add: `vultrbuilder "github.com/hashicorp/packer/builder/vultr"`
- - in `Builders` map add: `"vultr":   new(vultrbuilder.Builder),`
- 
-Then you can `go install` Packer, and it will have support for the "vultr"
-plugin.
+- Move the plugin from where Go put it to the plugin directory:
+
+`mv $(go env GOBIN)/packer-builder-vultr ~/.packer.d/plugins/`
+
+That's it. Builder type `vultr` should now work.
 
 ## Configuration
 

--- a/go.sum
+++ b/go.sum
@@ -109,7 +109,7 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/go-oracle-terraform v0.0.0-20181016190316-007121241b79/go.mod h1:09jT3Y/OIsjTjQ2+3bkVNPDKqWcGIYYvjB2BEKVUdvc=
 github.com/hashicorp/go-retryablehttp v0.5.2 h1:AoISa4P4IsW0/m4T6St8Yw38gTl5GtBAgfkhYh1xAz4=
 github.com/hashicorp/go-retryablehttp v0.5.2/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
-github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90 h1:9HVkPxOpo+yO93Ah4yrO67d/qh0fbLLWbKqhYjyHq9A=
+github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90 h1:VBj0QYQ0u2MCJzBfeYXGexnAl17GsH1yidnoxCqqD9E=
 github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90/go.mod h1:o4zcYY1e0GEZI6eSEr+43QDYmuGglw1qSO6qdHUHCgg=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=


### PR DESCRIPTION
Thanks to Go module support, packer-builder-vultr can be built as a Packer plugin without changing the Packer source.

For dradtke/packer-builder-vultr#8
